### PR TITLE
lsp: rewrite the buffer format keymap

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -143,10 +143,10 @@ M.lsp_attach = function(client, bufnr)
 
   -- Set some keybinds conditional on server capabilities
   if client.resolved_capabilities.document_formatting then
-    buf_set_keymap("n", "<space>m", "<cmd>lua vim.lsp.buf.formatting()<CR>",
+    buf_set_keymap("n", "gf", "<cmd>lua vim.lsp.buf.formatting()<CR>",
                    opts)
   elseif client.resolved_capabilities.document_range_formatting then
-    buf_set_keymap("n", "<space>m",
+    buf_set_keymap("x", "gf",
                    "<cmd>lua vim.lsp.buf.range_formatting()<CR>", opts)
   end
 end


### PR DESCRIPTION
* Replace keymap `<space>m` with `gf` for `vim.lsp.buf.formatting` API
* Replace keymap `<space>m` with `gf` in select mode for `vim.lsp.buf.range_formatting` API

Closed #9 