### PR TITLE
fix/keymap: fix lightspeed and surround conflict

### DIFF
--- a/lua/partial/enhance.lua
+++ b/lua/partial/enhance.lua
@@ -154,6 +154,12 @@ return {
   {
     "tpope/vim-surround",
     event = "BufRead",
+    config = function ()
+      -- release the S key to the lightspeed
+      require('utils').map("x", "S", "<Plug>Lightspeed_S", {noremap = false})
+      -- and remap it to gs
+      require('utils').map("x", "gs", "<Plug>VSurround", {noremap = false})
+    end
   },
 
   -- a swiss knife for aligning text
@@ -186,6 +192,7 @@ return {
       {'n', 's'},
       {'v', 's'},
       {'n', 'S'},
+      {'v', 'S'},
       {'n', 'f'},
       {'n', 'F'},
       {'n', 't'},


### PR DESCRIPTION
* Map key S to lightspeed backward jump function in visual mode
* Map key gs for the VSurround function

Close #13 