### PR TITLE
lspsaga: removed option keys that are no longer supported

### DIFF
--- a/lua/plugins/coding/config/init.lua
+++ b/lua/plugins/coding/config/init.lua
@@ -183,7 +183,6 @@ config.lspsaga_config = function()
     -- when cursor in saga window you config these to move
     move_in_saga = { prev = "k", next = "j" },
     diagnostic_header = { " ", " ", " ", " " },
-    diagnostic_source_bracket = { "戀", ":" },
     scroll_in_preview = {
       scroll_down = "<C-d>",
       scroll_up = "<C-u>",
@@ -208,7 +207,6 @@ config.lspsaga_config = function()
       scroll_down = "<C-f>",
       scroll_up = "<C-b>", -- quit can be a table
     },
-    definition_preview_icon = "  ",
     -- show symbols in winbar must be neovim 0.8.0,
     -- close it until neovim 0.8.0 become stable
     symbol_in_winbar = {


### PR DESCRIPTION
![issue](https://user-images.githubusercontent.com/53322490/190035209-47c1bdf5-dcbc-48c0-ae33-47d4a43f1c79.png)

新版本移除了一些option，如果我们继续用的话它会报错。[Version 2.2 #501](https://github.com/glepnir/lspsaga.nvim/pull/501)
