### PR TITLE
fix #68

### DIFF
--- a/lua/overlays/rc/null_ls.lua
+++ b/lua/overlays/rc/null_ls.lua
@@ -23,4 +23,8 @@ end
 require("null-ls").setup({
   sources = sources,
   on_attach = attachment.lsp_keymap,
+  -- update the diagnostics only after leaving insert-mode.
+  -- keep in sync with vim.lsp behavior which is configured
+  -- in lspconfig.lua to avoid the diagnostics update conflict.
+  update_in_insert = false,
 })


### PR DESCRIPTION
`update_in_insert` means the diagnostics will be updated in insert mode. The lsp server will be running in regardless of this config.

`null-ls` has a setting called `only run in file save`, it means the eslint server will be only run & provide diagnostics on file save.

`null-ls` also has setting with same name and same behavior called `update_in_insert`.

We need to make sure `null-ls` behavior the same as vim.lsp, so the diagnostics update will be working without conflict.